### PR TITLE
Do not instrument Identifier when preceded by typeof

### DIFF
--- a/instrument.js
+++ b/instrument.js
@@ -388,6 +388,11 @@ Instrumentor.prototype.wrap = function(tree, ignoredLines) {
                           parent.type == 'DoWhileStatement'))) {
                         return;
                     }
+                    // Do not instrument Identifier when preceded by typeof
+                    if (parent.operator == 'typeof') {
+                        return;
+                    }
+
                 }
                 var newNode = {
                     "type": "SequenceExpression",


### PR DESCRIPTION
When an identifier isn't declared, it's valid to use it in one specific expression: 

```
 typeof foo; // 'undefined'
```

Since it's instrumented by `node-cover`, it fails.

```
cover run test.js
ReferenceError: foo is not defined
```

This pull request remove the instrumentation of identifiers when their parent node is a  `typeof` operator.
